### PR TITLE
Implement possibility to apply changes immediately with commit() instead of apply()

### DIFF
--- a/kotlinpreferences-lib/build.gradle
+++ b/kotlinpreferences-lib/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'com.github.dcendents.android-maven'
 
-group='com.marcinmoskala.kotlinpreferences'
+group='com.github.felixdivo.kotlinpreferences'
 
 android {
     compileSdkVersion 25

--- a/kotlinpreferences-lib/build.gradle
+++ b/kotlinpreferences-lib/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'com.github.dcendents.android-maven'
 
-group='com.github.felixdivo.kotlinpreferences'
+group='com.github.felixdivo'
 
 android {
     compileSdkVersion 25

--- a/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/KotlinPreferences.kt
+++ b/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/KotlinPreferences.kt
@@ -8,26 +8,26 @@ import com.marcinmoskala.kotlinpreferences.bindings.PropertyWithBackupNullable
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KClass
 
-inline fun <reified T : Any> bindToPreferenceField(default: T?, key: String? = null): ReadWriteProperty<SharedPreferences, T>
-        = bindToPreferenceField(T::class, default, key)
+inline fun <reified T : Any> bindToPreferenceField(default: T?, key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T>
+        = bindToPreferenceField(T::class, default, key, applyAsync)
 
-inline fun <reified T : Any> bindToPreferenceFieldNullable(key: String? = null): ReadWriteProperty<SharedPreferences, T?>
-        = bindToPreferenceFieldNullable(T::class, key)
+inline fun <reified T : Any> bindToPreferenceFieldNullable(key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T?>
+        = bindToPreferenceFieldNullable(T::class, key, applyAsync)
 
-inline fun <reified T : Any> bindAsPropertyWithBackup(default: T?, key: String? = null): ReadWriteProperty<SharedPreferences, T>
-        = bindAsPropertyWithBackup(T::class, default, key)
+inline fun <reified T : Any> bindAsPropertyWithBackup(default: T?, key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T>
+        = bindAsPropertyWithBackup(T::class, default, key, applyAsync)
 
-inline fun <reified T : Any> bindAsPropertyWithBackupNullable(key: String? = null): ReadWriteProperty<SharedPreferences, T?>
-        = bindAsPropertyWithBackupNullable(T::class, key)
+inline fun <reified T : Any> bindAsPropertyWithBackupNullable(key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T?>
+        = bindAsPropertyWithBackupNullable(T::class, key, applyAsync)
 
-fun <T : Any> bindToPreferenceField(clazz: KClass<T>, default: T?, key: String? = null): ReadWriteProperty<SharedPreferences, T>
-        = PreferenceFieldDelegate(clazz, default, key)
+fun <T : Any> bindToPreferenceField(clazz: KClass<T>, default: T?, key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T>
+        = PreferenceFieldDelegate(clazz, default, key, applyAsync)
 
-fun <T : Any> bindToPreferenceFieldNullable(clazz: KClass<T>, key: String? = null): ReadWriteProperty<SharedPreferences, T?>
-        = PreferenceFieldDelegateNullable(clazz, key)
+fun <T : Any> bindToPreferenceFieldNullable(clazz: KClass<T>, key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T?>
+        = PreferenceFieldDelegateNullable(clazz, key, applyAsync)
 
-fun <T : Any> bindAsPropertyWithBackup(clazz: KClass<T>, default: T?, key: String? = null): ReadWriteProperty<SharedPreferences, T>
-        = PropertyWithBackup(clazz, default, key)
+fun <T : Any> bindAsPropertyWithBackup(clazz: KClass<T>, default: T?, key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T>
+        = PropertyWithBackup(clazz, default, key, applyAsync)
 
-fun <T : Any> bindAsPropertyWithBackupNullable(clazz: KClass<T>, key: String? = null): ReadWriteProperty<SharedPreferences, T?>
-        = PropertyWithBackupNullable(clazz, key)
+fun <T : Any> bindAsPropertyWithBackupNullable(clazz: KClass<T>, key: String? = null, applyAsync: Boolean = true): ReadWriteProperty<SharedPreferences, T?>
+        = PropertyWithBackupNullable(clazz, key, applyAsync)

--- a/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/bindings/PreferenceFieldDelegate.kt
+++ b/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/bindings/PreferenceFieldDelegate.kt
@@ -10,14 +10,18 @@ import kotlin.reflect.KProperty
 internal open class PreferenceFieldDelegate<T : Any>(
         private val clazz: KClass<T>,
         private val default: T?,
-        private val key: String?
+        private val key: String? = null,
+        private val applyAsync: Boolean = true
 ) : ReadWriteProperty<SharedPreferences, T> {
 
-    override operator fun getValue(thisRef: SharedPreferences, property: KProperty<*>): T
-            = thisRef.getValue<T>(clazz, default, getKey(property))
+    override operator fun getValue(thisRef: SharedPreferences, property: KProperty<*>): T = thisRef.getValue(clazz, default, getKey(property))
 
     override fun setValue(thisRef: SharedPreferences, property: KProperty<*>, value: T) {
-        thisRef.edit().apply { putValue(clazz, value, getKey(property)) }.apply()
+        val editor = thisRef.edit().apply { putValue(clazz, value, getKey(property)) }
+        if (applyAsync)
+            editor.apply()
+        else
+            editor.commit()
     }
 
     private fun getKey(property: KProperty<*>) = key ?: "${property.name}Key"

--- a/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/bindings/PropertyWithBackup.kt
+++ b/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/bindings/PropertyWithBackup.kt
@@ -5,7 +5,12 @@ import kotlin.concurrent.thread
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-internal class PropertyWithBackup<T : Any>(clazz: KClass<T>, default: T?, key: String?) : PreferenceFieldDelegate<T>(clazz, default, key) {
+internal class PropertyWithBackup<T : Any>(
+        clazz: KClass<T>,
+        default: T?,
+        key: String?,
+        applyAsync: Boolean = true)
+    : PreferenceFieldDelegate<T>(clazz, default, key, applyAsync) {
 
     var field: T? = null
 
@@ -13,7 +18,7 @@ internal class PropertyWithBackup<T : Any>(clazz: KClass<T>, default: T?, key: S
             field ?: super.getValue(thisRef, property).apply { field = this }
 
     override fun setValue(thisRef: SharedPreferences, property: KProperty<*>, value: T) {
-        if(value == field) return
+        if (value == field) return
         field = value
         thread {
             super.setValue(thisRef, property, value)

--- a/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/bindings/PropertyWithBackupNullable.kt
+++ b/kotlinpreferences-lib/src/main/java/com/marcinmoskala/kotlinpreferences/bindings/PropertyWithBackupNullable.kt
@@ -5,7 +5,11 @@ import kotlin.concurrent.thread
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-internal class PropertyWithBackupNullable<T : Any>(clazz: KClass<T>, key: String? = null) : PreferenceFieldDelegateNullable<T>(clazz, key) {
+internal class PropertyWithBackupNullable<T : Any>(
+        clazz: KClass<T>,
+        key: String? = null,
+        applyAsync: Boolean = true
+) : PreferenceFieldDelegateNullable<T>(clazz, key, applyAsync) {
 
     var propertySet: Boolean = false
     var field: T? = null
@@ -19,7 +23,7 @@ internal class PropertyWithBackupNullable<T : Any>(clazz: KClass<T>, key: String
 
     override fun setValue(thisRef: SharedPreferences, property: KProperty<*>, value: T?) {
         propertySet = true
-        if(value == field) return
+        if (value == field) return
         field = value
         thread {
             super.setValue(thisRef, property, value)


### PR DESCRIPTION
Existing users will not need to change anything: It is entirely opt-in, without the need for any more options to be set when defining the properties.

This feature is required in some multithreaded projects in order to avoid race conditions.